### PR TITLE
add sync task support via thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Fast, async, type-safe job queuing with Redis streams
 ## Features
 
 - Up to [5x-15x faster](/benchmarks) than arq
-- 100% typed
+- Strongly typed
 - 90%+ unit test coverage
 - Comprehensive documentation
-- Support for delayed tasks and cron jobs
+- Support for delayed/scheduled tasks
+- Cron jobs
+- Task sequencing via dependencies
+- Second-class support for synchronous tasks (run in separate threads)
 - Dead simple--under 2k lines of code
 - Web UI included (work in progress!)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ authors = [
     { name = "Graeme Holliday", email = "graeme@tastyware.dev" }
 ]
 dependencies = [
+    "anyio>=4.8.0",
     "crontab>=1.0.1",
     "redis[hiredis]>=5.2.1",
     "typer>=0.15.2",

--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)

--- a/streaq/task.py
+++ b/streaq/task.py
@@ -374,7 +374,7 @@ class RegisteredCron(Generic[WD, R]):
     unique: bool
     worker: "Worker"
 
-    def enqueue(self) -> Task[None]:
+    def enqueue(self) -> Task[R]:
         """
         Serialize the task and send it to the queue for later execution by an active worker.
         Though this isn't async, it should be awaited as it returns an object that should be.

--- a/streaq/task.py
+++ b/streaq/task.py
@@ -365,8 +365,8 @@ class RegisteredTask(Generic[WD, P, R]):
 
 
 @dataclass
-class RegisteredCron(Generic[WD]):
-    fn: Callable[[WrappedContext[WD]], Coroutine[Any, Any, None]]
+class RegisteredCron(Generic[WD, R]):
+    fn: Callable[[WrappedContext[WD]], Coroutine[Any, Any, R]]
     max_tries: int | None
     crontab: CronTab
     timeout: timedelta | int | None
@@ -381,7 +381,7 @@ class RegisteredCron(Generic[WD]):
         """
         return Task((), {}, self)
 
-    async def run(self) -> None:
+    async def run(self) -> R:
         """
         Run the task in the local event loop and return the result.
         This skips enqueuing and result storing in Redis.

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -68,17 +68,17 @@ async def test_task_cron(worker: Worker):
         pass
 
     @worker.cron("* * * * * * *")  # once/second
-    async def cron2(ctx: WrappedContext[None]) -> None:
-        pass
+    async def cron2(ctx: WrappedContext[None]) -> bool:
+        return True
 
     async with worker:
         schedule = cron1.schedule()
         assert schedule.day == 1 and schedule.month == 1
-        await cron2.run()
-        task = cron2.enqueue()
+        await cron1.run()
+        task = cron2.enqueue()  # by not awaiting we just get the task obj
         worker.loop.create_task(worker.run_async())
-        with pytest.raises(StreaqError):
-            await task.result(3)
+        res = await task.result(3)
+        assert res.result and res.success
 
 
 async def test_task_info(redis_url: str):

--- a/uv.lock
+++ b/uv.lock
@@ -1373,6 +1373,7 @@ wheels = [
 name = "streaq"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "crontab" },
     { name = "redis", extra = ["hiredis"] },
     { name = "typer" },
@@ -1406,6 +1407,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.8.0" },
     { name = "arq", marker = "extra == 'benchmark'", git = "https://github.com/graeme22/arq" },
     { name = "crontab", specifier = ">=1.0.1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.7" },


### PR DESCRIPTION
## Description
Adds support for running sync tasks via `any.to_thread.run_sync` and `asyncer.asyncify`.
Sync tasks will be run in separate threads to avoid blocking the thread pool. They are still type safe and can be used just like normal tasks.

## Pre-merge checklist
- [X] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [X] New tests added (if applicable)
