### PR TITLE
Add by ID task fns for abort, status, info, result

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -8,7 +8,7 @@ You can define middleware to wrap task execution. This has a host of potential a
 
 .. code-block:: python
 
-   from time import time
+   import time
    from typing import Callable, Coroutine
 
    @worker.middleware
@@ -30,7 +30,7 @@ You can register as many middleware as you like to a worker, which will run them
 
 .. code-block:: python
 
-   from time import time
+   import time
    from typing import Callable, Coroutine
    from streaq import StreaqRetry
 

--- a/docs/task.rst
+++ b/docs/task.rst
@@ -78,6 +78,15 @@ Tasks can depend on other tasks, meaning they won't be enqueued until their depe
        task2 = await sleeper.enqueue(2).start(after=task1.id)
        task3 = await sleeper.enqueue(3).start(after=[task1.id, task2.id])
 
+Running tasks locally
+---------------------
+
+Sometimes, you may wish to run a task's underlying function directly and skip enqueuing entirely. This can be done easily:
+
+.. code-block:: python
+
+   await sleeper.run(3)
+
 Task status & results
 ---------------------
 

--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)

--- a/streaq/task.py
+++ b/streaq/task.py
@@ -217,6 +217,8 @@ class Task(Generic[R]):
     async def status(self) -> TaskStatus:
         """
         Fetch the current status of the task.
+
+        :return: current task status
         """
         return await self.parent.worker.status_by_id(self.id)
 


### PR DESCRIPTION
## Description
Moves most of the code for ``Task.result()``, ``Task.status()``, ``Task.info()``, and ``Task.abort()`` to the worker, allowing for running these functions for tasks where all we have is the ID. The original functions remain but are now just wrappers for the code in the worker.

## Related issue(s)
Fixes #12

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
