### PR TITLE
Updating cron schedule overrides old one

### DIFF
--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)

--- a/streaq/lua.py
+++ b/streaq/lua.py
@@ -46,18 +46,16 @@ local task_data = ARGV[3]
 local priority = ARGV[4]
 local score = ARGV[5]
 
-if not redis.call('set', task_key, task_data, 'nx', 'px', ttl) then
-  return 0
-end
-
-if not score then
+if redis.call('set', task_key, task_data, 'nx', 'px', ttl) and not score then
   local message_id = redis.call('xadd', stream_key .. priority, '*', 'task_id', task_id)
   redis.call('set', message_key, message_id, 'px', ttl)
   return message_id
-else
+elseif score then
   redis.call('zadd', queue_key, score, task_id)
   return 1
 end
+
+return 0
 """
 
 PUBLISH_DELAYED_TASK = """

--- a/streaq/lua.py
+++ b/streaq/lua.py
@@ -46,13 +46,14 @@ local task_data = ARGV[3]
 local priority = ARGV[4]
 local score = ARGV[5]
 
-if redis.call('set', task_key, task_data, 'nx', 'px', ttl) and not score then
+local is_new = redis.call('set', task_key, task_data, 'nx', 'px', ttl)
+if score then
+  redis.call('zadd', queue_key, score, task_id)
+  return 1
+elseif is_new then
   local message_id = redis.call('xadd', stream_key .. priority, '*', 'task_id', task_id)
   redis.call('set', message_key, message_id, 'px', ttl)
   return message_id
-elseif score then
-  redis.call('zadd', queue_key, score, task_id)
-  return 1
 end
 
 return 0

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -461,9 +461,7 @@ class Worker(Generic[WD]):
         # schedule initial cron jobs
         for name, cron_job in self.cron_jobs.items():
             self.cron_schedule[name] = cron_job.next()
-            futures.add(
-                cron_job.enqueue().start(schedule=cron_job.schedule(), update=True)
-            )
+            futures.add(cron_job.enqueue().start(schedule=cron_job.schedule()))
         if futures:
             logger.debug(f"enqueuing {len(futures)} cron jobs in worker {self.id}")
             await asyncio.gather(*futures)

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -457,11 +457,13 @@ class Worker(Generic[WD]):
         jobs to the live queue when ready.
         """
         message_prefix = self._prefix + REDIS_MESSAGE
-        # schedule initial cron jobs
         futures = set()
+        # schedule initial cron jobs
         for name, cron_job in self.cron_jobs.items():
             self.cron_schedule[name] = cron_job.next()
-            futures.add(cron_job.enqueue().start(schedule=cron_job.schedule()))
+            futures.add(
+                cron_job.enqueue().start(schedule=cron_job.schedule(), update=True)
+            )
         if futures:
             logger.debug(f"enqueuing {len(futures)} cron jobs in worker {self.id}")
             await asyncio.gather(*futures)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -188,7 +188,7 @@ async def test_change_cron_schedule(redis_url: str):
     )
     foo1 = worker1.cron("0 0 1 1 *")(foo)
     worker1.loop.create_task(worker1.run_async())
-    await asyncio.sleep(1)
+    await asyncio.sleep(2)
     await worker1.close()
     task1 = foo1.enqueue()
     assert foo1.schedule() == (await task1.info()).scheduled
@@ -201,7 +201,7 @@ async def test_change_cron_schedule(redis_url: str):
     )
     foo2 = worker2.cron("1 0 1 1 *")(foo)  # 1 minute later
     worker2.loop.create_task(worker2.run_async())
-    await asyncio.sleep(3)
+    await asyncio.sleep(2)
     await worker2.close()
     task2 = foo2.enqueue()
     assert foo2.schedule() == (await task2.info()).scheduled


### PR DESCRIPTION
## Description
Re-enqueuing previously enqueued unique jobs doesn't do anything. This is intended behavior, except in the case of cron jobs (or any delayed job) having its schedule changed. In this case, we prefer to update the schedule while leaving everything else unchanged.

So now, if you create a cron job and later change its schedule, you can know it will work without doing anything extra

## Related issue(s)
Fixes #20

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
