### PR TITLE
fix: fully type decorators and wrappers

### DIFF
--- a/streaq/types.py
+++ b/streaq/types.py
@@ -1,13 +1,30 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Generic, ParamSpec, TypeVar
+from typing import (
+    Concatenate,
+    Generic,
+    ParamSpec,
+    Protocol,
+    Callable,
+    Coroutine,
+    Any,
+    TypeAlias,
+    TYPE_CHECKING,
+    overload,
+    TypeVar,
+)
 
 from coredis import Redis
+
+if TYPE_CHECKING:
+    from streaq.task import RegisteredTask, RegisteredCron
 
 P = ParamSpec("P")
 POther = ParamSpec("POther")
 R = TypeVar("R")
 ROther = TypeVar("ROther")
+RCo = TypeVar("RCo", covariant=True)
 WD = TypeVar("WD")
 
 
@@ -38,3 +55,58 @@ class WrappedContext(Generic[WD]):
     tries: int
     ttl: timedelta | int | None
     worker_id: str
+
+
+Middleware: TypeAlias = Callable[
+    [WrappedContext[WD], Callable[..., Coroutine]], Callable[..., Coroutine]
+]
+
+
+CronTaskFn: TypeAlias = Callable[[WrappedContext[WD]], Coroutine[Any, Any, R] | R]
+
+
+class CronTaskDefinitionWrapper(Protocol, Generic[WD]):
+    def __call__(self, fn: CronTaskFn[WD, R]) -> RegisteredCron[WD, R]: ...
+
+
+TaskFn: TypeAlias = Callable[Concatenate[WrappedContext[WD], P], R]
+
+
+AsyncTaskFn: TypeAlias = Callable[
+    Concatenate[WrappedContext[WD], P], Coroutine[Any, Any, R]
+]
+
+
+class NamedTaskFunc(Protocol, Generic[WD, P, RCo]):
+    def __call__(
+        self, ctx: WrappedContext[WD], *args: P.args, **kwds: P.kwargs
+    ) -> RCo: ...
+
+
+class AsyncNamedTaskFunc(Protocol, Generic[WD, P, RCo]):
+    async def __call__(
+        self, ctx: WrappedContext[WD], *args: P.args, **kwds: P.kwargs
+    ) -> RCo: ...
+
+
+class TaskDefinitionWrapper(Protocol, Generic[WD]):
+    @overload
+    def __call__(self, fn: TaskFn[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+    @overload
+    def __call__(self, fn: AsyncTaskFn[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+
+    @overload
+    def __call__(self, fn: NamedTaskFunc[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+
+    @overload
+    def __call__(  # type: ignore
+        self, fn: AsyncNamedTaskFunc[WD, P, R]
+    ) -> RegisteredTask[WD, P, R]: ...
+
+    def __call__(
+        self,
+        fn: AsyncNamedTaskFunc[WD, P, R]
+        | NamedTaskFunc[WD, P, R]
+        | AsyncTaskFn[WD, P, R]
+        | TaskFn[WD, P, R],
+    ) -> RegisteredTask[WD, P, R]: ...

--- a/streaq/types.py
+++ b/streaq/types.py
@@ -23,9 +23,8 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")
 POther = ParamSpec("POther")
-R = TypeVar("R")
+R = TypeVar("R", covariant=True)
 ROther = TypeVar("ROther")
-RCo = TypeVar("RCo", covariant=True)
 WD = TypeVar("WD")
 
 
@@ -78,16 +77,16 @@ AsyncTaskFn: TypeAlias = Callable[
 ]
 
 
-class NamedTaskFunc(Protocol, Generic[WD, P, RCo]):
+class NamedTaskFunc(Protocol, Generic[WD, P, R]):
     def __call__(
         self, ctx: WrappedContext[WD], *args: P.args, **kwds: P.kwargs
-    ) -> RCo: ...
+    ) -> R: ...
 
 
-class AsyncNamedTaskFunc(Protocol, Generic[WD, P, RCo]):
+class AsyncNamedTaskFunc(Protocol, Generic[WD, P, R]):
     async def __call__(
         self, ctx: WrappedContext[WD], *args: P.args, **kwds: P.kwargs
-    ) -> RCo: ...
+    ) -> R: ...
 
 
 class TaskDefinitionWrapper(Protocol, Generic[WD]):

--- a/streaq/types.py
+++ b/streaq/types.py
@@ -61,20 +61,17 @@ Middleware: TypeAlias = Callable[
     [WrappedContext[WD], Callable[..., Coroutine]], Callable[..., Coroutine]
 ]
 
-
 CronTaskFn: TypeAlias = Callable[[WrappedContext[WD]], Coroutine[Any, Any, R] | R]
 
-
-class CronTaskDefinitionWrapper(Protocol, Generic[WD]):
-    def __call__(self, fn: CronTaskFn[WD, R]) -> RegisteredCron[WD, R]: ...
-
-
 TaskFn: TypeAlias = Callable[Concatenate[WrappedContext[WD], P], R]
-
 
 AsyncTaskFn: TypeAlias = Callable[
     Concatenate[WrappedContext[WD], P], Coroutine[Any, Any, R]
 ]
+
+
+class CronTaskDefinitionWrapper(Protocol, Generic[WD]):
+    def __call__(self, fn: CronTaskFn[WD, R]) -> RegisteredCron[WD, R]: ...
 
 
 class NamedTaskFunc(Protocol, Generic[WD, P, R]):

--- a/streaq/types.py
+++ b/streaq/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import (
@@ -71,7 +69,7 @@ AsyncTaskFn: TypeAlias = Callable[
 
 
 class CronTaskDefinitionWrapper(Protocol, Generic[WD]):
-    def __call__(self, fn: CronTaskFn[WD, R]) -> RegisteredCron[WD, R]: ...
+    def __call__(self, fn: CronTaskFn[WD, R]) -> "RegisteredCron[WD, R]": ...
 
 
 class NamedTaskFunc(Protocol, Generic[WD, P, R]):
@@ -88,17 +86,17 @@ class AsyncNamedTaskFunc(Protocol, Generic[WD, P, R]):
 
 class TaskDefinitionWrapper(Protocol, Generic[WD]):
     @overload
-    def __call__(self, fn: TaskFn[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+    def __call__(self, fn: TaskFn[WD, P, R]) -> "RegisteredTask[WD, P, R]": ...  # type: ignore
     @overload
-    def __call__(self, fn: AsyncTaskFn[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+    def __call__(self, fn: AsyncTaskFn[WD, P, R]) -> "RegisteredTask[WD, P, R]": ...  # type: ignore
 
     @overload
-    def __call__(self, fn: NamedTaskFunc[WD, P, R]) -> RegisteredTask[WD, P, R]: ...  # type: ignore
+    def __call__(self, fn: NamedTaskFunc[WD, P, R]) -> "RegisteredTask[WD, P, R]": ...  # type: ignore
 
     @overload
     def __call__(  # type: ignore
         self, fn: AsyncNamedTaskFunc[WD, P, R]
-    ) -> RegisteredTask[WD, P, R]: ...
+    ) -> "RegisteredTask[WD, P, R]": ...
 
     def __call__(
         self,
@@ -106,4 +104,4 @@ class TaskDefinitionWrapper(Protocol, Generic[WD]):
         | NamedTaskFunc[WD, P, R]
         | AsyncTaskFn[WD, P, R]
         | TaskFn[WD, P, R],
-    ) -> RegisteredTask[WD, P, R]: ...
+    ) -> "RegisteredTask[WD, P, R]": ...

--- a/streaq/types.py
+++ b/streaq/types.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
     Concatenate,
+    Coroutine,
     Generic,
     ParamSpec,
     Protocol,
-    Callable,
-    Coroutine,
-    Any,
     TypeAlias,
-    TYPE_CHECKING,
-    overload,
     TypeVar,
+    overload,
 )
 
 from coredis import Redis
 
 if TYPE_CHECKING:
-    from streaq.task import RegisteredTask, RegisteredCron
+    from streaq.task import RegisteredCron, RegisteredTask
 
 P = ParamSpec("P")
 POther = ParamSpec("POther")


### PR DESCRIPTION
## Description
First of all, thanks for creating this project. I'm always looking out for new python redis task queue since I always find something lacking and this one looks promising on the surface so far. When trying it out the first time, I saw that strict mypy does not like the not fully typed decorators and wrappers. This PR addresses this problem.
## Related issue(s)
None

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
