### PR TITLE
add silent option for tasks, health check is now silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ class Context:
 
 @asynccontextmanager
 async def lifespan(worker: Worker) -> AsyncIterator[Context]:
+    """
+    Here, we initialize the worker's dependencies.
+    You can also do any startup/shutdown work here!
+    """
     async with AsyncClient() as http_client:
         yield Context(http_client)
 
@@ -66,7 +70,7 @@ async def fetch(ctx: WrappedContext[Context], url: str) -> int:
     r = await ctx.deps.http_client.get(url)
     return len(r.text)
 
-@worker.cron("* * * * mon-fri")
+@worker.cron("* * * * mon-fri")  # every minute on weekdays
 async def cronjob(ctx: WrappedContext[Context]) -> None:
     print("It's a bird... It's a plane... It's CRON!")
 ```
@@ -101,14 +105,9 @@ Let's see what the output looks like:
 [INFO] 19:49:46: task dc844a5b5f394caa97e4c6e702800eba ← 15
 [INFO] 19:49:50: task 178c4f4e057942d6b6269b38f5daaaa1 → worker db064c92
 [INFO] 19:49:50: task 178c4f4e057942d6b6269b38f5daaaa1 ← 293784
-[INFO] 19:50:00: task a0a8c0f39dae4c448182c417b047677c → worker db064c92
 [INFO] 19:50:00: task cde2413d9593470babfd6d4e36cf4570 → worker db064c92
 It's a bird... It's a plane... It's CRON!
 [INFO] 19:50:00: task cde2413d9593470babfd6d4e36cf4570 ← None
-[INFO] 19:50:00: health check results:
-redis {memory: 1.72M, clients: 3, keys: 18, queued: 2, scheduled: 0}
-worker db064c92 {completed: 2}
-[INFO] 19:50:00: task a0a8c0f39dae4c448182c417b047677c ← None
 ```
 ```
 TaskData(fn_name='fetch', enqueue_time=1743468587037, task_try=None, scheduled=datetime.datetime(2025, 4, 1, 0, 49, 50, 37000, tzinfo=datetime.timezone.utc))

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -21,6 +21,10 @@ To start, you'll need to create a ``Worker`` object:
 
    @asynccontextmanager
    async def lifespan(worker: Worker) -> AsyncIterator[Context]:
+       """
+       Here, we initialize the worker's dependencies.
+       You can also do any startup/shutdown work here!
+       """
        async with AsyncClient() as http_client:
            yield Context(http_client)
 
@@ -37,7 +41,7 @@ You can then register async tasks with the worker like this:
        r = await ctx.deps.http_client.get(url)
        return len(r.text)
 
-   @worker.cron("* * * * mon-fri")
+   @worker.cron("* * * * mon-fri")  # every minute on weekdays
    async def cronjob(ctx: WrappedContext[Context]) -> None:
        print("It's a bird... It's a plane... It's CRON!")
 
@@ -75,14 +79,9 @@ Let's see what the output looks like:
    [INFO] 19:49:46: task dc844a5b5f394caa97e4c6e702800eba ← 15
    [INFO] 19:49:50: task 178c4f4e057942d6b6269b38f5daaaa1 → worker db064c92
    [INFO] 19:49:50: task 178c4f4e057942d6b6269b38f5daaaa1 ← 293784
-   [INFO] 19:50:00: task a0a8c0f39dae4c448182c417b047677c → worker db064c92
    [INFO] 19:50:00: task cde2413d9593470babfd6d4e36cf4570 → worker db064c92
    It's a bird... It's a plane... It's CRON!
    [INFO] 19:50:00: task cde2413d9593470babfd6d4e36cf4570 ← None
-   [INFO] 19:50:00: health check results:
-   redis {memory: 1.72M, clients: 3, keys: 18, queued: 2, scheduled: 0}
-   worker db064c92 {completed: 2}
-   [INFO] 19:50:00: task a0a8c0f39dae4c448182c417b047677c ← None
 
 .. code-block:: python
 

--- a/docs/task.rst
+++ b/docs/task.rst
@@ -40,6 +40,7 @@ We can now register async functions with the worker:
 The ``task`` decorator has several optional arguments that can be used to customize behavior:
 
 - ``max_tries``: maximum number of attempts before giving up if task is retried; defaults to 3
+- ``silent``: whether to silence task startup/shutdown logs and task success/failure tracking; defaults to False
 - ``timeout``: amount of time to run the task before raising ``asyncio.TimeoutError``; ``None`` (the default) means never timeout
 - ``ttl``: amount of time to store task result in Redis; defaults to 5 minutes. ``None`` means never delete results, ``0`` means never store results
 - ``unique``: whether to prevent more than one instance of the task running simultaneously; defaults to ``False`` for normal tasks and ``True`` for cron jobs. (Note that more than one instance may be queued, but two running at once will cause the second to fail.)

--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "2.1.1"
+VERSION = "2.2.0"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)

--- a/streaq/task.py
+++ b/streaq/task.py
@@ -274,6 +274,7 @@ class Task(Generic[R]):
 class RegisteredTask(Generic[WD, P, R]):
     fn: Callable[Concatenate[WrappedContext[WD], P], TypedCoroutine[R]]
     max_tries: int | None
+    silent: bool
     timeout: timedelta | int | None
     ttl: timedelta | int | None
     unique: bool
@@ -325,8 +326,9 @@ class RegisteredTask(Generic[WD, P, R]):
 @dataclass
 class RegisteredCron(Generic[WD, R]):
     fn: Callable[[WrappedContext[WD]], TypedCoroutine[R]]
-    max_tries: int | None
     crontab: CronTab
+    max_tries: int | None
+    silent: bool
     timeout: timedelta | int | None
     ttl: timedelta | int | None
     unique: bool

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -59,8 +59,8 @@ async def test_health_check(redis_url: str):
     await worker.redis.flushdb()
     worker.loop.create_task(worker.run_async())
     await asyncio.sleep(2)
-    worker_health = await worker.redis.hget(worker._health_key, worker.id)
-    redis_health = await worker.redis.hget(worker._health_key, "redis")
+    worker_health = await worker.redis.get(f"{worker._health_key}:{worker.id}")
+    redis_health = await worker.redis.get(worker._health_key + ":redis")
     assert worker_health is not None
     assert redis_health is not None
     await worker.close()


### PR DESCRIPTION
## Description
- Adds new `silent` parameter to tasks which prevents logging task startup/shutdown information and removes silent tasks from success/failure tracking.
- Health check is now silent and the task itself doesn't log at all (but info is still stored in Redis).
- Health check results stored in Redis now have a TTL, which could be used to detect worker failures.

## Related issue(s)
Similar to #23

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
