### PR TITLE
Prepare new major version: cleaner function signatures

### DIFF
--- a/benchmarks/bench_streaq.py
+++ b/benchmarks/bench_streaq.py
@@ -3,7 +3,7 @@ from typing import Awaitable
 
 import typer
 
-from streaq import Worker, WrappedContext
+from streaq import Worker
 
 worker = Worker(concurrency=32, with_scheduler=False)
 N_TASKS = 20_000
@@ -17,7 +17,7 @@ async def sem_task(task: Awaitable):
 
 
 @worker.task()
-async def sleeper(ctx: WrappedContext[None], time: int) -> None:
+async def sleeper(time: int) -> None:
     if time:
         await asyncio.sleep(time)
 

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -45,7 +45,7 @@ First, you can simply use type stubs to re-define the task signatures in the bac
    worker = Worker(redis_url="redis://localhost:6379")
 
    @worker.task()
-   async def fetch(ctx, url: str) -> int: ...
+   async def fetch(url: str) -> int: ...
 
 Now, tasks can be enqueued in the same way as before:
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -9,11 +9,12 @@ You can define middleware to wrap task execution. This has a host of potential a
 .. code-block:: python
 
    import time
-   from typing import Callable, Coroutine
+   from streaq.types import ReturnCoroutine
+   from typing import Any
 
    @worker.middleware
-   def timer(ctx: WrappedContext[Context], task: Callable[..., Coroutine]):
-       async def wrapper(*args, **kwargs):
+   def timer(task: ReturnCoroutine) -> ReturnCoroutine:
+       async def wrapper(*args, **kwargs) -> Any:
            start_time = time.perf_counter()
            result = await task(*args, **kwargs)
            print(f"Executed task {ctx.task_id} in {time.perf_counter() - start_time:.3f}s")
@@ -30,13 +31,11 @@ You can register as many middleware as you like to a worker, which will run them
 
 .. code-block:: python
 
-   import time
-   from typing import Callable, Coroutine
    from streaq import StreaqRetry
 
    @worker.middleware
-   def timer(ctx: WrappedContext[Context], task: Callable[..., Coroutine]):
-       async def wrapper(*args, **kwargs):
+   def timer(task: ReturnCoroutine) -> ReturnCoroutine:
+       async def wrapper(*args, **kwargs) -> Any:
            start_time = time.perf_counter()
            result = await task(*args, **kwargs)
            print(f"Executed task {ctx.task_id} in {time.perf_counter() - start_time:.3f}s")
@@ -45,8 +44,8 @@ You can register as many middleware as you like to a worker, which will run them
        return wrapper
 
    @worker.middleware
-   def retry(ctx: WrappedContext[Context], task: Callable[..., Coroutine]):
-       async def wrapper(*args, **kwargs):
+   def retry(task: ReturnCoroutine) -> ReturnCoroutine:
+       async def wrapper(*args, **kwargs) -> Any:
            try:
                return await task(*args, **kwargs)
            except Exception:

--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "2.2.2"
+VERSION = "3.0.0"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)
@@ -9,15 +9,15 @@ logger.setLevel(logging.DEBUG)
 # ruff: noqa: E402
 
 from .task import StreaqRetry, TaskPriority, TaskStatus
-from .types import WrappedContext
+from .types import TaskContext
 from .utils import StreaqError
 from .worker import Worker
 
 __all__ = [
     "StreaqError",
     "StreaqRetry",
+    "TaskContext",
     "TaskPriority",
     "TaskStatus",
     "Worker",
-    "WrappedContext",
 ]

--- a/tests/failure.py
+++ b/tests/failure.py
@@ -1,14 +1,14 @@
 import asyncio
 import sys
 
-from streaq import Worker, WrappedContext
+from streaq import Worker
 
 
 async def test_reclaim_idle_task(redis_url: str):
     worker1 = Worker(redis_url=redis_url, queue_name="test")
 
     @worker1.task(timeout=3)
-    async def foo(ctx: WrappedContext[None]) -> None:
+    async def foo() -> None:
         await asyncio.sleep(2)
 
     await worker1.run_async()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,18 +1,19 @@
 import asyncio
 import time
 from datetime import datetime, timedelta
-from typing import Callable, Coroutine
+from typing import Any
 
 import pytest
 
-from streaq import StreaqError, Worker, WrappedContext
+from streaq import StreaqError, Worker
 from streaq.constants import REDIS_RUNNING
 from streaq.task import StreaqRetry, TaskPriority, TaskStatus
+from streaq.types import ReturnCoroutine
 
 
 async def test_result_timeout(worker: Worker):
     @worker.task(ttl=0)
-    async def foobar(ctx: WrappedContext[None]) -> bool:
+    async def foobar() -> bool:
         return False
 
     task = await foobar.enqueue()
@@ -23,7 +24,7 @@ async def test_result_timeout(worker: Worker):
 
 async def test_task_timeout(worker: Worker):
     @worker.task(timeout=1)
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(5)
 
     task = await foobar.enqueue()
@@ -35,7 +36,7 @@ async def test_task_timeout(worker: Worker):
 
 async def test_task_status(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(1)
 
     task = foobar.enqueue()
@@ -51,7 +52,7 @@ async def test_task_status(worker: Worker):
 
 async def test_task_status_running(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(3)
 
     task = await foobar.enqueue().start()
@@ -63,11 +64,11 @@ async def test_task_status_running(worker: Worker):
 
 async def test_task_cron(worker: Worker):
     @worker.cron("30 9 1 1 *")
-    async def cron1(ctx: WrappedContext[None]) -> bool:
+    async def cron1() -> bool:
         return True
 
     @worker.cron("* * * * * * *")  # once/second
-    async def cron2(ctx: WrappedContext[None]) -> None:
+    async def cron2() -> None:
         await asyncio.sleep(3)
 
     schedule = cron1.schedule()
@@ -83,7 +84,7 @@ async def test_task_info(redis_url: str):
     worker = Worker(redis_url=redis_url)
 
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         pass
 
     async with worker:
@@ -95,7 +96,8 @@ async def test_task_info(redis_url: str):
 
 async def test_task_retry(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> int:
+    async def foobar() -> int:
+        ctx = worker.task_context()
         if ctx.tries < 3:
             raise StreaqRetry("Retrying!")
         return ctx.tries
@@ -109,7 +111,8 @@ async def test_task_retry(worker: Worker):
 
 async def test_task_retry_with_delay(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> int:
+    async def foobar() -> int:
+        ctx = worker.task_context()
         if ctx.tries == 1:
             raise StreaqRetry("Retrying!", delay=3)
         return ctx.tries
@@ -126,7 +129,7 @@ async def test_task_retry_with_delay(worker: Worker):
 
 async def test_task_failure(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         raise Exception("That wasn't supposed to happen!")
 
     task = await foobar.enqueue()
@@ -138,8 +141,8 @@ async def test_task_failure(worker: Worker):
 
 async def test_task_retry_no_delay(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> bool:
-        if ctx.tries == 1:
+    async def foobar() -> bool:
+        if worker.task_context().tries == 1:
             raise StreaqRetry("Retrying!", delay=0)
         return True
 
@@ -153,7 +156,7 @@ async def test_task_retry_no_delay(worker: Worker):
 
 async def test_task_max_retries(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         raise StreaqRetry("Retrying!", delay=0)
 
     task = await foobar.enqueue()
@@ -166,7 +169,7 @@ async def test_task_max_retries(worker: Worker):
 
 async def test_task_failed_abort(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> bool:
+    async def foobar() -> bool:
         return True
 
     worker.burst = True
@@ -181,7 +184,7 @@ async def test_task_failed_abort(worker: Worker):
 
 async def test_task_nonexistent_or_finished_dependency(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         pass
 
     task = await foobar.enqueue().start(after="nonexistent")
@@ -192,7 +195,7 @@ async def test_task_nonexistent_or_finished_dependency(worker: Worker):
 
 async def test_task_dependency(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(1)
 
     task = await foobar.enqueue().start(delay=1)
@@ -206,7 +209,7 @@ async def test_task_dependency(worker: Worker):
 
 async def test_task_dependency_multiple(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(1)
 
     task = await foobar.enqueue().start()
@@ -226,11 +229,11 @@ async def test_task_dependency_multiple(worker: Worker):
 
 async def test_task_dependency_failed(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         raise Exception("Oh no!")
 
     @worker.task()
-    async def do_nothing(ctx: WrappedContext[None]) -> None:
+    async def do_nothing() -> None:
         pass
 
     task = await foobar.enqueue().start()
@@ -243,7 +246,7 @@ async def test_task_dependency_failed(worker: Worker):
 
 async def test_sync_task(worker: Worker):
     @worker.task()
-    def foobar(ctx: WrappedContext[None]) -> None:
+    def foobar() -> None:
         time.sleep(2)
 
     task = await foobar.enqueue()
@@ -256,7 +259,7 @@ async def test_sync_task(worker: Worker):
 
 async def test_unsafe_enqueue(redis_url: str, worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None], ret: int) -> int:
+    async def foobar(ret: int) -> int:
         return ret
 
     worker.loop.create_task(worker.run_async())
@@ -271,11 +274,11 @@ async def test_unsafe_enqueue(redis_url: str, worker: Worker):
 
 async def test_chained_failed_dependencies(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         raise Exception("Oh no!")
 
     @worker.task()
-    async def child(ctx: WrappedContext[None]) -> None:
+    async def child() -> None:
         pass
 
     task = await foobar.enqueue().start(delay=3)
@@ -294,7 +297,7 @@ async def test_task_priorities(redis_url: str):
     worker = Worker(redis_url=redis_url, queue_name="test", concurrency=4)
 
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(1)
 
     async with worker:
@@ -314,7 +317,7 @@ async def test_task_priorities(redis_url: str):
 
 async def test_scheduled_task(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         pass
 
     dt = datetime.now() + timedelta(seconds=1)
@@ -329,7 +332,7 @@ async def test_bad_start_params(redis_url: str):
     worker = Worker(redis_url=redis_url)
 
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         pass
 
     with pytest.raises(StreaqError):
@@ -342,7 +345,7 @@ async def test_bad_start_params(redis_url: str):
 
 async def test_enqueue_unique_task(worker: Worker):
     @worker.task(unique=True)
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         await asyncio.sleep(1)
 
     task = await foobar.enqueue()
@@ -355,7 +358,7 @@ async def test_enqueue_unique_task(worker: Worker):
 
 async def test_failed_abort(worker: Worker):
     @worker.task(ttl=0)
-    async def foobar(ctx: WrappedContext[None]) -> None:
+    async def foobar() -> None:
         pass
 
     task = await foobar.enqueue().start()
@@ -368,11 +371,11 @@ async def test_cron_run(redis_url: str):
     worker = Worker(redis_url=redis_url)
 
     @worker.cron("* * * * * * *")
-    async def cron1(ctx: WrappedContext[None]) -> bool:
+    async def cron1() -> bool:
         return True
 
     @worker.cron("* * * * * * *", timeout=1)
-    async def cron2(ctx: WrappedContext[None]) -> None:
+    async def cron2() -> None:
         await asyncio.sleep(3)
 
     async with worker:
@@ -383,7 +386,7 @@ async def test_cron_run(redis_url: str):
 
 async def test_sync_cron(worker: Worker):
     @worker.cron("* * * * * * *")
-    def cronjob(ctx: WrappedContext[None]) -> None:
+    def cronjob() -> None:
         time.sleep(3)
 
     worker.loop.create_task(worker.run_async())
@@ -395,8 +398,8 @@ async def test_cron_multiple_runs(worker: Worker):
     key = "runs"
 
     @worker.cron("* * * * * * *")
-    async def cronjob(ctx: WrappedContext[None]) -> None:
-        await ctx.redis.incr(key)
+    async def cronjob() -> None:
+        await worker.redis.incr(key)
 
     worker.loop.create_task(worker.run_async())
     await asyncio.sleep(3)
@@ -406,12 +409,12 @@ async def test_cron_multiple_runs(worker: Worker):
 
 async def test_middleware(worker: Worker):
     @worker.task()
-    async def foobar(ctx: WrappedContext[None]) -> int:
+    async def foobar() -> int:
         return 2
 
     @worker.middleware
-    def double(ctx: WrappedContext[None], task: Callable[..., Coroutine]):
-        async def wrapper(*args, **kwargs):
+    def double(task: ReturnCoroutine) -> ReturnCoroutine:
+        async def wrapper(*args, **kwargs) -> Any:
             result = await task(*args, **kwargs)
             return result * 2
 
@@ -426,11 +429,11 @@ async def test_middleware(worker: Worker):
 
 async def test_task_pipeline(worker: Worker):
     @worker.task()
-    async def double(ctx: WrappedContext[None], val: int) -> int:
+    async def double(val: int) -> int:
         return val * 2
 
     @worker.task()
-    async def is_even(ctx: WrappedContext[None], val: int) -> bool:
+    async def is_even(val: int) -> bool:
         return val % 2 == 0
 
     worker.loop.create_task(worker.run_async())


### PR DESCRIPTION
## Description
- Context is no longer part of task functions' signatures. This means less code, less warnings, and more intuitive behavior everywhere.
- API changes:
  * `WrappedContext.deps` -> `Worker.context`
  * `WrappedContext` -> `Worker.task_context()`
  * `ctx` parameter in tasks and cron jobs is now gone. Code that used to look like this:
    ```python
    @worker.task(timeout=5)
    async def fetch(ctx: WrappedContext[Context], url: str) -> int:
        res = await ctx.deps.http_client.get(url)
        return len(res.text)
    
    @worker.cron("* * * * mon-fri")
    async def cronjob(ctx: WrappedContext[Context]) -> None:
        print("It's a bird... It's a plane... It's CRON!")
    ```
    Should be changed to:
    ```python
    @worker.task(timeout=5)
    async def fetch(url: str) -> int:
        res = await worker.context.http_client.get(url)
        return len(res.text)
    
    @worker.cron("* * * * mon-fri")
    async def cronjob() -> None:
        print("It's a bird... It's a plane... It's CRON!")
    ```

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
