### PR TITLE
Сheck main_task attribute when closing worker

### DIFF
--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -1135,19 +1135,15 @@ class Worker(Generic[WD]):
         """
         Cleanup worker and Redis connection
         """
-
         if not self.main_task:
+            logger.warning("Unable to close worker that hasn't started yet!")
             return
-
         self._block_new_tasks = True
         for t in self.tasks.values():
             if not t.done():
                 t.cancel()
-
         self.main_task.cancel()
         await asyncio.gather(*self.task_wrappers.values(), self.main_task)
-        self.main_task = None
-
         run_time = now_ms() - self._start_time
         logger.info(f"shutdown {str(self)} after {run_time}ms")
 


### PR DESCRIPTION
## Description
If we did not call run worker, and call the `close` method, we will get an error that the `main_task` attribute does not exist. We must initialize `main_task` in the constructor and check the value in the `close` method.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
