### PR TITLE
Exception handling when aborting tasks with ttl=0

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -361,6 +361,18 @@ async def test_enqueue_unique_task(worker: Worker):
     assert any(r.result is None for r in results)
 
 
+@pytest.mark.parametrize("ttl", [60, 0])
+async def test_abort(worker: Worker, ttl: int):
+    @worker.task(ttl=ttl)
+    async def foobar() -> None:
+        await asyncio.sleep(5)
+
+    task = await foobar.enqueue()
+    worker.loop.create_task(worker.run_async())
+    await asyncio.sleep(1)
+    assert await task.abort(1)
+
+
 async def test_failed_abort(worker: Worker):
     @worker.task(ttl=0)
     async def foobar() -> None:


### PR DESCRIPTION
## Description
We must catch the `StreaqError` exception for tasks with ttl=0. Also, we must check that this exception is not caused by a deserialization error. An additional check on task info has also been added.

## Related issue(s)
Fixes #57 

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [ ] Docs updated (if applicable)
