### PR TITLE
Add missing Jinja2 dependency to extra "web" dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ benchmark = [
 web = [
     "async-lru>=2.0.5",
     "fastapi>=0.115.12",
+    "jinja2>=3.1.6",
     "python-multipart>=0.0.20",
     "uvicorn>=0.34.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1740,6 +1740,7 @@ benchmark = [
 web = [
     { name = "async-lru" },
     { name = "fastapi" },
+    { name = "jinja2" },
     { name = "python-multipart" },
     { name = "uvicorn" },
 ]
@@ -1769,6 +1770,7 @@ requires-dist = [
     { name = "coredis", specifier = ">=5.0.0" },
     { name = "crontab", specifier = ">=1.0.5" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.12" },
+    { name = "jinja2", marker = "extra == 'web'", specifier = ">=3.1.6" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = ">=0.0.20" },
     { name = "saq", extras = ["hiredis"], marker = "extra == 'benchmark'", specifier = "==0.22.2" },
     { name = "taskiq-redis", marker = "extra == 'benchmark'", specifier = "==1.0.3" },


### PR DESCRIPTION
## Description
This PR adds a forgotten Jinja2 dependency for the extra dependency group “web”.

In dev environment, this dependency is present because Sphinx package transitively depends on it. But if there are no other dependencies in the project that depend on Jinja2, it will not be installed for `streaq[web]` and it will cause an error when using the web dashboard.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
