### PR TITLE
Do not configure logging level by default

### DIFF
--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -4,7 +4,7 @@ VERSION = "4.1.1"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.NullHandler())
 
 # ruff: noqa: E402
 


### PR DESCRIPTION
## Description
This PR removes `DEBUG` level for the logger and adds `NullHandler` by default. These changes do not affect CLI because the logger is additionally configured there.

We don't have to configure levels for logging by default for the library. Because logging should configure at the level of the project that uses the library. If we set the level to `DEBUG` for the streaq logger, when we set the level for the root logger, we cannot control the level for the streaq logger. 

For example, we want to set INFO level for all loggers in a project by setting the level for the root logger:
```yaml
logging:
  version: 1
  disable_existing_loggers: false
  root:
    level: INFO
```

If the streaq logger already has the DEBUG level, the above configuration example will not set the INFO level for it.
In this case, we would have to explicitly define the configuration for streaq:
```yaml
loggers:
  streaq:
    propagate: false
    level: INFO
```

It is good practice to set `NullHandler` by default to the library logger.
See for more details: https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
