### PR TITLE
Do not install uvloop on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "coredis>=5.0.1",
     "crontab>=1.0.5",
     "typer>=0.15.2",
-    "uvloop>=0.21.0",
+    "uvloop>=0.21.0; sys_platform != 'win32'",
     "watchfiles>=1.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Description
Do not install uvloop dependency on Windows because uvloop does not support Windows platform.

## Related issue(s)
Fixes #70

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
