### PR TITLE
[docs] Add complements for enqueue_unsafe function and use of customized name for tasks

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -64,6 +64,9 @@ The second way is to use ``Worker.enqueue_unsafe``:
 
 This method is not type-safe, but it doesn't require you to re-define the task signature in the backend. Here, the first parameter is the ``fn_name`` of the task defined elsewhere, and the rest of the args and kwargs can be passed normally.
 
+.. note::
+   Despite ``enqueue_unsafe`` being synchronous, it relies on asynchronous code under the hood. Therefore, it has to be awaited to run as expected.
+
 Web UI integration
 ------------------
 

--- a/docs/task.rst
+++ b/docs/task.rst
@@ -43,7 +43,7 @@ The ``task`` decorator has several optional arguments that can be used to custom
 
 - ``expire``: time after which to dequeue the task, if None will never be dequeued
 - ``max_tries``: maximum number of attempts before giving up if task is retried; defaults to 3
-- ``name``: use a custom name for the task instead of the function name
+- ``name``: use a custom name for the task instead of the function name (see :ref:`Custom name for tasks <custom-name-for-task>` for related impacts and behavior)
 - ``silent``: whether to silence task startup/shutdown logs and task success/failure tracking; defaults to False
 - ``timeout``: amount of time to run the task before raising ``TimeoutError``; ``None`` (the default) means never timeout
 - ``ttl``: amount of time to store task result in Redis; defaults to 5 minutes. ``None`` means never delete results, ``0`` means never store results
@@ -324,3 +324,24 @@ This is useful for ETL pipelines or similar tasks, where each task builds upon t
 
 .. note::
    For pipelined tasks, positional arguments must all come from the previous task (tuple outputs will be unpacked), and any additional arguments can be passed as kwargs to ``then()``.
+
+.. _custom-name-for-task:
+
+Custom name for tasks
+---------------------
+
+As soon as you provide a custom name to a function using the ``name`` argument, you must call the task with the customized name and no longer with the function name. 
+
+.. code-block:: python
+
+   @worker.task(name="custom_sleeper")
+   async def sleeper(time: int) -> int:
+       await asyncio.sleep(time)
+       return time
+
+   # no longer correct
+   await sleeper.enqueue(3)
+   
+   # correct
+   await custom_sleeper.enqueue(3)
+   


### PR DESCRIPTION
## Description

Update documentation for `enqueue_unsafe` and custom name used in tasks based on #82 

## Related issue(s)

Fixes #82 

## Pre-merge checklist
- [ ] Code formatted correctly (check with `make lint`)
- [ ] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [x] Docs updated (if applicable)
