### PR TITLE
Add is_cron to TaskContext

### DIFF
--- a/streaq/types.py
+++ b/streaq/types.py
@@ -48,6 +48,7 @@ class TaskContext:
     timeout: timedelta | int | None
     tries: int
     ttl: timedelta | int | None
+    is_cron: bool
 
 
 AnyCoroutine: TypeAlias = Coroutine[Any, Any, Any]

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -358,6 +358,7 @@ class Worker(Generic[C]):
             timeout=registered_task.timeout,
             tries=tries,
             ttl=registered_task.ttl,
+            is_cron=isinstance(registered_task, RegisteredCron),
         )
 
     def cron(


### PR DESCRIPTION
## Description
Allow checking wether a task is a cron task in middleware.
There could be another way, if so, I didn't manage ti find it.

I want perform some custom handling in middleware only for cron/normal tasks.

## Related issue(s)
Fixes ...

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [ ] Docs updated (if applicable)
