### PR TITLE
Ability to set custom formatters for task results and exceptions in Web UI

### DIFF
--- a/streaq/ui/__init__.py
+++ b/streaq/ui/__init__.py
@@ -3,11 +3,16 @@ import sys
 from typing import Any, AsyncGenerator, cast
 
 from streaq import Worker
-from streaq.ui.deps import get_worker
+from streaq.ui.deps import get_exception_formatter, get_result_formatter, get_worker
 from streaq.ui.tasks import router
 from streaq.utils import import_string
 
-__all__ = ["get_worker", "router"]
+__all__ = [
+    "get_worker",
+    "get_result_formatter",
+    "get_exception_formatter",
+    "router",
+]
 
 
 def run_web(host: str, port: int, worker_path: str) -> None:  # pragma: no cover

--- a/streaq/ui/deps.py
+++ b/streaq/ui/deps.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Any
+from traceback import format_exception
+from typing import Any, Callable
 
 from fastapi import HTTPException, status
 from fastapi.templating import Jinja2Templates
@@ -15,3 +16,14 @@ def get_worker() -> Worker[Any]:
         status_code=status.HTTP_412_PRECONDITION_FAILED,
         detail="get_worker dependency not implemented!",
     )
+
+
+def get_result_formatter() -> Callable[[Any], str]:
+    return str
+
+
+def get_exception_formatter() -> Callable[[BaseException], str]:
+    def _format_exc(exc: BaseException):
+        return "".join(format_exception(exc))
+
+    return _format_exc

--- a/streaq/ui/deps.py
+++ b/streaq/ui/deps.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from textwrap import shorten
 from traceback import format_exception
 from typing import Any, Callable
 
@@ -20,10 +19,7 @@ def get_worker() -> Worker[Any]:
 
 
 def get_result_formatter() -> Callable[[Any], str]:
-    def _format_result(result: Any) -> str:
-        return shorten(str(result), width=80, placeholder="…")
-
-    return _format_result
+    return str
 
 
 def get_exception_formatter() -> Callable[[BaseException], str]:

--- a/streaq/ui/deps.py
+++ b/streaq/ui/deps.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import shorten
 from traceback import format_exception
 from typing import Any, Callable
 
@@ -19,11 +20,14 @@ def get_worker() -> Worker[Any]:
 
 
 def get_result_formatter() -> Callable[[Any], str]:
-    return str
+    def _format_result(result: Any) -> str:
+        return shorten(str(result), width=80, placeholder="…")
+
+    return _format_result
 
 
 def get_exception_formatter() -> Callable[[BaseException], str]:
-    def _format_exc(exc: BaseException):
+    def _format_exc(exc: BaseException) -> str:
         return "".join(format_exception(exc))
 
     return _format_exc

--- a/streaq/ui/templates/task.j2
+++ b/streaq/ui/templates/task.j2
@@ -48,7 +48,12 @@
             </tr>
             <tr>
               <th scope="row">Result</th>
-              <td>{{ result }}</td>
+                <td>
+                  <div class="border rounded p-2 overflow-y-auto overflow-x-auto bg-light"
+                       style="max-height: 300px; max-width: 100ch; white-space: pre;">
+                      {{- result|trim -}}
+                  </div>
+                </td>
             </tr>
             <tr>
               <th scope="row">Start Time</th>

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -9,6 +9,7 @@ from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone, tzinfo
 from inspect import iscoroutinefunction
 from sys import platform
+from textwrap import shorten
 from typing import Any, AsyncGenerator, Callable, Generic, Literal, cast
 from uuid import uuid4
 
@@ -795,10 +796,8 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                 pipe.delete(to_delete)
                 pipe.srem(self._abort_key, [task_id])
                 if success:
-                    output, truncate_length = str(return_value), 32
-                    if len(output) > truncate_length:
-                        output = f"{output[:truncate_length]}…"
                     if not silent:
+                        output = shorten(str(return_value), width=32)
                         logger.info(f"task {fn_name} ■ {task_id} ← {output}")
                     if triggers:
                         args = self.serialize(to_tuple(return_value))


### PR DESCRIPTION
## Description

- Show task result/exception info in the adaptive scroll area
- Add dependency functions `get_result_formatter` and `get_exception_formatter` to customize result/exception output

## Related issue(s)
Fixes #93

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
