### PR TITLE
Custom worker id feature

### DIFF
--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -96,6 +96,7 @@ Other configuration options
 - ``anyio_backend``: either trio or asyncio, defaults to asyncio
 - ``anyio_kwargs``: extra arguments for anyio, see documentation `here <https://anyio.readthedocs.io/en/stable/basics.html#backend-specific-options>`_
 - ``sentinel_kwargs``: extra arguments to pass to sentinel connections (see below)
+- ``id``: a custom worker ID. You must ensure that it is unique for the specified queue name.
 
 Deploying with Redis Sentinel
 -----------------------------

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -206,6 +206,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         sentinel_nodes: list[tuple[str, int]] | None = None,
         sentinel_master: str = "mymaster",
         sentinel_kwargs: dict[str, Any] | None = None,
+        id: str | None = None,
     ):
         # Redis connection
         redis_kwargs = redis_kwargs or {}
@@ -242,7 +243,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         #: mapping of task name -> next execution time in ms
         self.cron_schedule: dict[str, int] = defaultdict(int)
         #: unique ID of worker
-        self.id = uuid4().hex[:8]
+        self.id = id or uuid4().hex[:8]
         self.serializer = serializer
         self.deserializer = deserializer
         self.tz = tz

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -316,3 +316,10 @@ async def test_enqueue_many(worker: Worker):
 async def test_invalid_task_context(worker: Worker):
     with pytest.raises(StreaqError):
         worker.task_context()
+
+
+async def test_custom_worker_id(redis_url: str):
+    worker_id = uuid4().hex
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex, id=worker_id)
+
+    assert worker.id == worker_id


### PR DESCRIPTION
## Description
The PR adds ability to set a custom worker id.

## Related issue(s)
Fixes #98 

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [x] Docs updated (if applicable)
