### PR TITLE
Place sleep after the first healthcheck, not before it.

### DIFF
--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -1214,9 +1214,9 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         Periodically stores info about the worker in Redis.
         """
         while True:
-            await sleep(self._delay_for(self._health_tab))
             ttl = int(self._delay_for(self._health_tab)) + 5
             await self.redis.set(f"{self._health_key}:{self.id}", str(self), ex=ttl)
+            await sleep(self._delay_for(self._health_tab))
 
     async def signal_handler(self, scope: CancelScope) -> None:
         """


### PR DESCRIPTION
## Description

It is more correct to sleep after the first health check key has been placed in Redis. Otherwise, we will not set the health check key in Redis at startup for some time, depending on the set health check interval.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
