### PR TITLE
Add the info about exception traceback serialization with tblib to the docs

### DIFF
--- a/docs/task.rst
+++ b/docs/task.rst
@@ -162,6 +162,36 @@ Enqueued tasks return a ``Task`` object which can be used to wait for task resul
 
 The ``TaskResult`` object contains information about the task, such as start/end time. The ``success`` flag will tell you whether the object stored in ``result`` is the result of task execution (if ``True``) or an exception raised during execution (if ``False``).
 
+Task exceptions
+---------------
+
+If an exception occurs while performing the task, the result.success flag will be set to ``False``. The exception object itself will be available in the ``exception`` property of ``TaskResult``.
+
+.. code-block:: python
+
+    async with worker:
+        result = await task.result()
+
+        if not result.success:
+            print(result.exception)
+
+.. important::
+
+    If you're using the default serialization (pickle), the exception object won't contain traceback information, since pickle doesn't natively support serializing traceback objects — this information will be lost during serialization and deserialization.
+
+    To keep the full traceback details for exceptions, you can use the `python-tblib <https://github.com/ionelmc/python-tblib>`_ package. This package makes it easy to serialize traceback objects with pickle. In most cases just two lines of code are needed to add this support:
+
+    .. code-block:: python
+
+        from tblib import pickling_support
+
+        # Declare your own custom Exceptions
+        ...
+
+        # Finally, install tblib
+        pickling_support.install()
+
+
 Task context
 ------------
 


### PR DESCRIPTION
## Description

The problem is that pickle out of the box does not support serialization of exception tracebacks. This information is simply lost, so we cannot obtain valuable information about exceptions from queue tasks.

The PR adds the information to the documentation about exception traceback serialization using [python-tblib](https://github.com/ionelmc/python-tblib).
If the tblib package is installed, a full traceback will be available for all exceptions raised in tasks when we get the task result after deserialization.

The code for example:
```python
# app.py

from tblib import pickling_support

class MyCustomError(Exception):
    pass

async def foo():
    raise MyCustomError('Ooops, something went wrong!')

@worker.task()
async def hello():
    try:
        await foo()
    except ValueError as err:
        raise TypeError(f'ERROR: {err}') from err

pickling_support.install()
```

With installed tblib for this code we will get the following traceback for the exception after the result deserialization:
```
Traceback (most recent call last):
  File "/home/esp/work/github/streaq/app.py", line 89, in hello
    await foo()
  File "/home/esp/work/github/streaq/app.py", line 81, in foo
    raise MyCustomError('Ooops, something went wrong!')
app.MyCustomError: Ooops, something went wrong!

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/esp/work/github/streaq/streaq/worker.py", line 1032, in run_task
    result = await wrapped(*_args, **data["k"])
  File "/home/esp/work/github/streaq/streaq/worker.py", line 1018, in _fn
    return await task.fn(*args, **kwargs)
  File "/home/esp/work/github/streaq/app.py", line 91, in hello
    raise ValueError(f'ERROR: {err}') from err
ValueError: ERROR: Ooops, something went wrong!
```

Without installed tblib we will get the exception without traceback info because a traceback was lost in the exception:
```
TypeError: ERROR: Ooops, something went wrong!
```

## Related issue(s)
The problem of traceback loss in exceptions was raised in the [comment](https://github.com/tastyware/streaq/pull/95#issuecomment-3341987844).

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [x] Docs updated (if applicable)
