### PR TITLE
Improve the user experience when running tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     image: redis:latest
     container_name: redis-master
     hostname: redis-master
-    ports:
-      - "6379:6379"
     volumes:
       - ./data/master:/data
     command:
@@ -30,8 +28,6 @@ services:
     hostname: slave-1
     depends_on:
       - redis-master
-    ports:
-      - "6380:6379"
     volumes:
       - ./data/slave1:/data
     command:
@@ -60,8 +56,6 @@ services:
     hostname: slave-2
     depends_on:
       - redis-master
-    ports:
-      - "6381:6379"
     volumes:
       - ./data/slave2:/data
     command:
@@ -90,8 +84,6 @@ services:
     hostname: sentinel-1
     depends_on:
       - redis-master
-    ports:
-      - "26379:26379"
     command: >
       sh -c 'echo "bind 0.0.0.0" > /etc/sentinel.conf &&
             echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&
@@ -113,8 +105,6 @@ services:
     hostname: sentinel-2
     depends_on:
       - redis-master
-    ports:
-      - "26380:26379"
     command: >
       sh -c 'echo "bind 0.0.0.0" > /etc/sentinel.conf &&
             echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&
@@ -136,8 +126,6 @@ services:
     hostname: sentinel-3
     depends_on:
       - redis-master
-    ports:
-      - "26381:26379"
     command: >
       sh -c 'echo "bind 0.0.0.0" > /etc/sentinel.conf &&
             echo "sentinel monitor mymaster redis-master 6379 2" >> /etc/sentinel.conf &&


### PR DESCRIPTION
## Description
This PR improves the user experience when running tests in docker compose.

Removed port publishing from Redis containers, as this could cause port conflicts, for example: if the user already has a Redis container running with port 6379 published. Redis containers do not need to be accessible from outside; they are used only for tests and should only be accessible within the Docker Compose network.

~~- Added the `docker compose down --remove-orphans` command after tests are run to stop and remove all running Redis containers.~~

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
