### PR TITLE
dynamic cron jobs

### DIFF
--- a/streaq/constants.py
+++ b/streaq/constants.py
@@ -1,6 +1,7 @@
 DEFAULT_QUEUE_NAME = "default"
 REDIS_ABORT = ":aborted"
 REDIS_CHANNEL = ":channels:"
+REDIS_CRON = ":cron"
 REDIS_DEPENDENCIES = ":task:dependencies:"
 REDIS_DEPENDENTS = ":task:dependents:"
 REDIS_GROUP = "workers"

--- a/streaq/types.py
+++ b/streaq/types.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from streaq.task import RegisteredCron, RegisteredTask
+    from streaq.task import RegisteredTask
 
 C = TypeVar("C", bound=Optional[object])
 P = ParamSpec("P")
@@ -64,10 +64,10 @@ SyncTask: TypeAlias = Callable[P, R]
 
 class CronDefinition(Protocol, Generic[C]):
     @overload
-    def __call__(self, fn: AsyncCron[R]) -> RegisteredCron[C, R]: ...
+    def __call__(self, fn: AsyncCron[R]) -> RegisteredTask[C, [], R]: ...
 
     @overload
-    def __call__(self, fn: SyncCron[R]) -> RegisteredCron[C, R]: ...  # type: ignore
+    def __call__(self, fn: SyncCron[R]) -> RegisteredTask[C, [], R]: ...  # type: ignore
 
 
 class TaskDefinition(Protocol, Generic[C]):

--- a/streaq/utils.py
+++ b/streaq/utils.py
@@ -62,10 +62,10 @@ def to_seconds(timeout: timedelta | int | None) -> float | None:
     return float(timeout) if timeout is not None else None
 
 
-def to_ms(timeout: timedelta | int) -> int:
+def to_ms(timeout: timedelta | int | float) -> int:
     if isinstance(timeout, timedelta):
         return round(timeout.total_seconds() * 1000)
-    return timeout * 1000
+    return round(timeout * 1000)
 
 
 def now_ms() -> int:
@@ -201,6 +201,8 @@ async def gather(*awaitables: Awaitable[T1]) -> tuple[T1, ...]: ...
 
 
 async def gather(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
+    if not awaitables:
+        return ()
     if len(awaitables) == 1:  # optimize for this case
         return (await awaitables[0],)
     results: list[Any] = [None] * len(awaitables)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_verbose(worker: Worker):
     setattr(test_module, "test_worker", worker)
     result = runner.invoke(cli, ["tests.test_cli:test_worker", "--burst", "--verbose"])
     assert result.exit_code == 0
-    assert "enqueuing" in result.stderr
+    assert "established" in result.stderr
 
 
 def test_version(worker: Worker):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from streaq.utils import import_string
+from streaq.utils import gather, import_string
+
+pytestmark = pytest.mark.anyio
 
 
 def test_bad_path():
@@ -11,3 +13,7 @@ def test_bad_path():
 def test_bad_worker_name():
     with pytest.raises(ImportError):
         _ = import_string("example:asdf")
+
+
+async def test_useless_gather():
+    await gather()


### PR DESCRIPTION
## Description
Moves cron registry to Redis. This allows for dynamically adding/removing cron jobs.

## Related issue(s)
Fixes #112

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [ ] Docs updated (if applicable)
