### PR TITLE
feat(worker): add max_schedule_drift to @worker.cron()

### DIFF
--- a/streaq/lua/streaq.lua
+++ b/streaq/lua/streaq.lua
@@ -66,8 +66,7 @@ redis.register_function('publish_delayed_tasks', function(keys, argv)
       local stream = stream_key .. priority
       -- add ready tasks to live queue, using scheduled fire time as enqueue_time
       for j=1, #tids, 2 do
-        local scheduled_time = tostring(math.floor(tonumber(tids[j+1])))
-        redis.call('xadd', stream, '*', 'task_id', tids[j], 'enqueue_time', scheduled_time)
+        redis.call('xadd', stream, '*', 'task_id', tids[j], 'enqueue_time', tids[j+1])
       end
     end
   end

--- a/streaq/lua/streaq.lua
+++ b/streaq/lua/streaq.lua
@@ -58,15 +58,16 @@ redis.register_function('publish_delayed_tasks', function(keys, argv)
   for i=2, #argv do
     local priority = argv[i]
     local queue = queue_key .. priority
-    -- get and delete tasks ready to run from delayed queue
-    local tids = redis.call('zrange', queue, 0, current_time, 'byscore')
+    -- get and delete tasks ready to run from delayed queue (with scores)
+    local tids = redis.call('zrange', queue, 0, current_time, 'byscore', 'withscores')
     if #tids > 0 then
       redis.call('zremrangebyscore', queue, 0, current_time)
 
       local stream = stream_key .. priority
-      -- add ready tasks to live queue
-      for j=1, #tids do
-        redis.call('xadd', stream, '*', 'task_id', tids[j], 'enqueue_time', current_time)
+      -- add ready tasks to live queue, using scheduled fire time as enqueue_time
+      for j=1, #tids, 2 do
+        local scheduled_time = tostring(math.floor(tonumber(tids[j+1])))
+        redis.call('xadd', stream, '*', 'task_id', tids[j], 'enqueue_time', scheduled_time)
       end
     end
   end

--- a/streaq/task.py
+++ b/streaq/task.py
@@ -353,6 +353,7 @@ class Task(Generic[R]):
 @dataclass(kw_only=True)
 class RegisteredTask:
     expire: timedelta | int | None
+    max_schedule_drift: timedelta | int | None
     max_tries: int | None
     silent: bool
     timeout: timedelta | int | None

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -393,6 +393,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         self,
         tab: str,
         *,
+        max_schedule_drift: timedelta | int | None = None,
         max_tries: int | None = 3,
         name: str | None = None,
         silent: bool = False,
@@ -406,6 +407,10 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         :param tab:
             crontab for scheduling, follows the specification
             `here <https://github.com/josiahcarlson/parse-crontab?tab=readme-ov-file#description>`_.
+        :param max_schedule_drift:
+            maximum time a cron task can sit in the stream unexecuted before being
+            discarded. Guards against stale replay after worker restart. If None
+            (default), no check is performed.
         :param max_tries:
             number of times to retry the task should it fail during execution
         :param name: use a custom name for the cron job instead of the function name
@@ -434,6 +439,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                 task = AsyncRegisteredTask(
                     fn=fn,
                     expire=None,
+                    max_schedule_drift=max_schedule_drift,
                     max_tries=max_tries,
                     silent=silent,
                     timeout=timeout,
@@ -449,6 +455,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
             task = SyncRegisteredTask(
                 fn=fn,
                 expire=None,
+                max_schedule_drift=max_schedule_drift,
                 max_tries=max_tries,
                 silent=silent,
                 timeout=timeout,
@@ -522,6 +529,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                 task = AsyncRegisteredTask(
                     fn=fn,
                     expire=expire,
+                    max_schedule_drift=None,
                     max_tries=max_tries,
                     silent=silent,
                     timeout=timeout,
@@ -537,6 +545,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
             task = SyncRegisteredTask(
                 fn=fn,
                 expire=expire,
+                max_schedule_drift=None,
                 max_tries=max_tries,
                 silent=silent,
                 timeout=timeout,
@@ -1034,6 +1043,20 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                 fn_name=fn_name,
                 ttl=task.ttl,
             )
+        if task.max_schedule_drift is not None:
+            if now_ms() - msg.enqueue_time > to_ms(task.max_schedule_drift):
+                if not task.silent:
+                    logger.warning(
+                        f"task † {task_id} exceeded max_schedule_drift, skipping"
+                    )
+                return await self.finish_failed_task(
+                    msg,
+                    StreaqError("Cron task exceeded max_schedule_drift!"),
+                    task_try,
+                    data["t"],
+                    fn_name=fn_name,
+                    ttl=task.ttl,
+                )
 
         timeout = (
             None if task.timeout is None else self.idle_timeout + to_ms(task.timeout)
@@ -1230,6 +1253,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         registered = AsyncRegisteredTask(
             fn=_placeholder,
             expire=None,
+            max_schedule_drift=None,
             max_tries=None,
             silent=False,
             timeout=None,

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -408,9 +408,8 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
             crontab for scheduling, follows the specification
             `here <https://github.com/josiahcarlson/parse-crontab?tab=readme-ov-file#description>`_.
         :param max_schedule_drift:
-            maximum time a cron task can sit in the stream unexecuted before being
-            discarded. Guards against stale replay after worker restart. If None
-            (default), no check is performed.
+            maximum amount of time a cron task can be delayed from its scheduled
+            execution time before getting discarded. If None, no check is performed.
         :param max_tries:
             number of times to retry the task should it fail during execution
         :param name: use a custom name for the cron job instead of the function name
@@ -1047,11 +1046,11 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
             if now_ms() - msg.enqueue_time > to_ms(task.max_schedule_drift):
                 if not task.silent:
                     logger.warning(
-                        f"task † {task_id} exceeded max_schedule_drift, skipping"
+                        f"task {fn_name} ⊘ {task_id} missed scheduled time, skipping"
                     )
                 return await self.finish_failed_task(
                     msg,
-                    StreaqError("Cron task exceeded max_schedule_drift!"),
+                    StreaqError("Cron task exceeded max schedule drift!"),
                     task_try,
                     data["t"],
                     fn_name=fn_name,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -612,7 +612,7 @@ async def test_cron_no_max_schedule_drift(redis_url: str):
 
 
 async def test_cron_max_schedule_drift_stale_via_zset(redis_url: str):
-    """Stale cron task promoted from the delayed ZSET (worker-restart path) is discarded."""
+    """Stale cron task promoted from delayed ZSET is discarded."""
     called = False
     worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 from uuid import uuid4
 
@@ -16,10 +17,10 @@ from anyio import create_task_group, sleep
 from coredis import RedisCluster
 from coredis.connection import TCPLocation
 
-from streaq.constants import REDIS_TASK
+from streaq.constants import REDIS_QUEUE, REDIS_TASK
 from streaq.task import TaskStatus
 from streaq.types import StreaqError, WorkerDepends
-from streaq.utils import gather
+from streaq.utils import gather, now_ms
 from streaq.worker import Worker
 from tests.conftest import run_worker
 
@@ -525,3 +526,115 @@ async def test_get_tasks_by_status_empty_done(worker: Worker):
 def test_health_tab():
     with pytest.warns(match="deprecated as it no longer does anything"):
         _ = Worker(health_crontab="*/5 * * * *")
+
+
+async def test_cron_max_schedule_drift_stale(redis_url: str):
+    """Stale cron task (enqueue_time older than max_schedule_drift) is discarded."""
+    called = False
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
+
+    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(seconds=5))
+    async def stale_job() -> None:
+        nonlocal called
+        called = True
+
+    stale_enqueue_time = now_ms() - 60_000  # 60 seconds ago, well outside 5s window
+    task = stale_job.enqueue()
+    serialized = task.serialize(stale_enqueue_time)
+
+    async with create_task_group() as tg:
+        await tg.start(worker.run_async)
+        # inject task data and stream entry with stale timestamp
+        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
+        await worker.redis.xadd(
+            worker.stream_key + worker.priorities[-1],
+            {"task_id": task.id, "enqueue_time": stale_enqueue_time},
+        )
+        result = await task.result(5)
+        assert not result.success
+        assert "max_schedule_drift" in str(result.exception)
+        assert not called
+        tg.cancel_scope.cancel()
+
+
+async def test_cron_max_schedule_drift_fresh(redis_url: str):
+    """Fresh cron task (enqueue_time within max_schedule_drift) executes normally."""
+    called = False
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
+
+    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(minutes=5))
+    async def fresh_job() -> None:
+        nonlocal called
+        called = True
+
+    fresh_enqueue_time = now_ms()  # enqueued right now, within 5-minute window
+    task = fresh_job.enqueue()
+    serialized = task.serialize(fresh_enqueue_time)
+
+    async with create_task_group() as tg:
+        await tg.start(worker.run_async)
+        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
+        await worker.redis.xadd(
+            worker.stream_key + worker.priorities[-1],
+            {"task_id": task.id, "enqueue_time": fresh_enqueue_time},
+        )
+        result = await task.result(5)
+        assert result.success
+        assert called
+        tg.cancel_scope.cancel()
+
+
+async def test_cron_no_max_schedule_drift(redis_url: str):
+    """Without max_schedule_drift set, stale tasks are never skipped."""
+    called = False
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
+
+    @worker.cron("0 0 1 1 *")  # no max_schedule_drift
+    async def no_drift_job() -> None:
+        nonlocal called
+        called = True
+
+    stale_enqueue_time = now_ms() - 3_600_000  # 1 hour ago
+    task = no_drift_job.enqueue()
+    serialized = task.serialize(stale_enqueue_time)
+
+    async with create_task_group() as tg:
+        await tg.start(worker.run_async)
+        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
+        await worker.redis.xadd(
+            worker.stream_key + worker.priorities[-1],
+            {"task_id": task.id, "enqueue_time": stale_enqueue_time},
+        )
+        result = await task.result(5)
+        assert result.success
+        assert called
+        tg.cancel_scope.cancel()
+
+
+async def test_cron_max_schedule_drift_stale_via_zset(redis_url: str):
+    """Stale cron task promoted from the delayed ZSET (the real worker-restart path) is discarded."""
+    called = False
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
+
+    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(seconds=5))
+    async def stale_zset_job() -> None:
+        nonlocal called
+        called = True
+
+    stale_score = now_ms() - 60_000  # scheduled 60 seconds ago, well outside 5s window
+    task = stale_zset_job.enqueue()
+    serialized = task.serialize(stale_score)
+
+    async with create_task_group() as tg:
+        await tg.start(worker.run_async)
+        # simulate restart scenario: task data in Redis, task ID in delayed ZSET with stale score
+        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
+        await worker.redis.zadd(
+            worker.prefix + REDIS_QUEUE + worker.priorities[-1],
+            {task.id: stale_score},
+        )
+        result = await task.result(5)
+        assert not result.success
+        assert "max_schedule_drift" in str(result.exception)
+        assert not called
+        tg.cancel_scope.cancel()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
@@ -17,10 +17,10 @@ from anyio import create_task_group, sleep
 from coredis import RedisCluster
 from coredis.connection import TCPLocation
 
-from streaq.constants import REDIS_QUEUE, REDIS_TASK
+from streaq.constants import REDIS_TASK
 from streaq.task import TaskStatus
 from streaq.types import StreaqError, WorkerDepends
-from streaq.utils import gather, now_ms
+from streaq.utils import gather
 from streaq.worker import Worker
 from tests.conftest import run_worker
 
@@ -528,113 +528,41 @@ def test_health_tab():
         _ = Worker(health_crontab="*/5 * * * *")
 
 
-async def test_cron_max_schedule_drift_stale(redis_url: str):
-    """Stale cron task (enqueue_time older than max_schedule_drift) is discarded."""
-    called = False
-    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
-
-    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(seconds=5))
-    async def stale_job() -> None:
-        nonlocal called
-        called = True
-
-    stale_enqueue_time = now_ms() - 60_000  # 60 seconds ago, well outside 5s window
-    task = stale_job.enqueue()
-    serialized = task.serialize(stale_enqueue_time)
+async def test_cron_max_schedule_drift_stale(worker: Worker):
+    @worker.cron("* * * * *", max_schedule_drift=timedelta(seconds=5))
+    async def every_minute() -> None: ...
 
     async with create_task_group() as tg:
         await tg.start(worker.run_async)
-        # inject task data and stream entry with stale timestamp
-        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
-        await worker.redis.xadd(
-            worker.stream_key + worker.priorities[-1],
-            {"task_id": task.id, "enqueue_time": stale_enqueue_time},
-        )
+        # simulate previously enqueued with old timestamp
+        task = await every_minute.enqueue().start(schedule=datetime(2022, 2, 22))
         result = await task.result(5)
         assert not result.success
-        assert "max_schedule_drift" in str(result.exception)
-        assert not called
+        assert "max schedule drift" in str(result.exception)
         tg.cancel_scope.cancel()
 
 
-async def test_cron_max_schedule_drift_fresh(redis_url: str):
-    """Fresh cron task (enqueue_time within max_schedule_drift) executes normally."""
-    called = False
-    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
-
-    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(minutes=5))
-    async def fresh_job() -> None:
-        nonlocal called
-        called = True
-
-    fresh_enqueue_time = now_ms()  # enqueued right now, within 5-minute window
-    task = fresh_job.enqueue()
-    serialized = task.serialize(fresh_enqueue_time)
+async def test_cron_max_schedule_drift_fresh(worker: Worker):
+    @worker.cron("* * * * *", max_schedule_drift=timedelta(seconds=5))
+    async def every_minute() -> None: ...
 
     async with create_task_group() as tg:
         await tg.start(worker.run_async)
-        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
-        await worker.redis.xadd(
-            worker.stream_key + worker.priorities[-1],
-            {"task_id": task.id, "enqueue_time": fresh_enqueue_time},
-        )
+        # simulate previously enqueued with old timestamp
+        task = await every_minute.enqueue()
         result = await task.result(5)
         assert result.success
-        assert called
         tg.cancel_scope.cancel()
 
 
-async def test_cron_no_max_schedule_drift(redis_url: str):
-    """Without max_schedule_drift set, stale tasks are never skipped."""
-    called = False
-    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
-
-    @worker.cron("0 0 1 1 *")  # no max_schedule_drift
-    async def no_drift_job() -> None:
-        nonlocal called
-        called = True
-
-    stale_enqueue_time = now_ms() - 3_600_000  # 1 hour ago
-    task = no_drift_job.enqueue()
-    serialized = task.serialize(stale_enqueue_time)
+async def test_cron_no_max_schedule_drift(worker: Worker):
+    @worker.cron("* * * * *")
+    async def every_minute() -> None: ...
 
     async with create_task_group() as tg:
         await tg.start(worker.run_async)
-        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
-        await worker.redis.xadd(
-            worker.stream_key + worker.priorities[-1],
-            {"task_id": task.id, "enqueue_time": stale_enqueue_time},
-        )
+        # simulate previously enqueued with old timestamp
+        task = await every_minute.enqueue().start(schedule=datetime(2022, 2, 22))
         result = await task.result(5)
         assert result.success
-        assert called
-        tg.cancel_scope.cancel()
-
-
-async def test_cron_max_schedule_drift_stale_via_zset(redis_url: str):
-    """Stale cron task promoted from delayed ZSET is discarded."""
-    called = False
-    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
-
-    @worker.cron("0 0 1 1 *", max_schedule_drift=timedelta(seconds=5))
-    async def stale_zset_job() -> None:
-        nonlocal called
-        called = True
-
-    stale_score = now_ms() - 60_000  # scheduled 60 seconds ago, well outside 5s window
-    task = stale_zset_job.enqueue()
-    serialized = task.serialize(stale_score)
-
-    async with create_task_group() as tg:
-        await tg.start(worker.run_async)
-        # simulate restart: task data in Redis, task ID in delayed ZSET with stale score
-        await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
-        await worker.redis.zadd(
-            worker.prefix + REDIS_QUEUE + worker.priorities[-1],
-            {task.id: stale_score},
-        )
-        result = await task.result(5)
-        assert not result.success
-        assert "max_schedule_drift" in str(result.exception)
-        assert not called
         tg.cancel_scope.cancel()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -612,7 +612,7 @@ async def test_cron_no_max_schedule_drift(redis_url: str):
 
 
 async def test_cron_max_schedule_drift_stale_via_zset(redis_url: str):
-    """Stale cron task promoted from the delayed ZSET (the real worker-restart path) is discarded."""
+    """Stale cron task promoted from the delayed ZSET (worker-restart path) is discarded."""
     called = False
     worker = Worker(redis_url=redis_url, queue_name=uuid4().hex)
 
@@ -627,7 +627,7 @@ async def test_cron_max_schedule_drift_stale_via_zset(redis_url: str):
 
     async with create_task_group() as tg:
         await tg.start(worker.run_async)
-        # simulate restart scenario: task data in Redis, task ID in delayed ZSET with stale score
+        # simulate restart: task data in Redis, task ID in delayed ZSET with stale score
         await worker.redis.set(worker.prefix + REDIS_TASK + task.id, serialized)
         await worker.redis.zadd(
             worker.prefix + REDIS_QUEUE + worker.priorities[-1],


### PR DESCRIPTION
## Description
Decided to go with per-job on the basis that different cron tasks in the same worker may have a different tolerance for staleness. But I am open for you to push back on that if you disagree.

When set, a task is discarded at execution time if `now - scheduled_fire_time` exceeds the window:

```python
@worker.cron("0 * * * *", max_schedule_drift=timedelta(minutes=5))
async def hourly_report():
    ...
```

Stale tasks are failed rather than silently dropped, so `task.result()` returns a `StreaqError` and it shows up in the UI. The silent flag suppresses the log warning, consistent with other failure paths. Default is `None` to ensure this is backwards compatible.

> [!NOTE]
> This required a change to `publish_delayed_tasks` in streaq.lua. It was stamping `enqueue_time = promotion_time` for tasks promoted from the delayed ZSET. It now uses the ZSET score (the scheduled due time) instead as otherwise it appears that the check would always see near-zero drift on restart since promotion happens at startup.

> [!IMPORTANT]
> `TaskResult.enqueue_time` now means "when the task was due" rather than "when Redis moved it into the live stream." Immediate tasks are unaffected. Flagging as I don't see that having a huge impact, but probably is worth highlighting due to slight change in behaviour.

Four tests: stale task discarded, fresh task runs, no drift set means always runs, and a fourth that exercises the real restart path through ZSET promotion rather than injecting directly into the stream.

## Related issue(s)
Fixes #152

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [ ] Docs updated (if applicable)
