### PR TITLE
fix middleware DI regression from v6.3.2

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -25,6 +25,9 @@ You can define middleware to wrap task execution. This has a host of potential a
 
 Middleware are structured as wrapped functions for maximum flexibility--not only can you run code before/after execution, you can also access and even modify the arguments or results.
 
+.. warning::
+   Adding named keyword arguments to middleware (such as ``ctx`` here) will shadow arguments in your tasks with the same name, so use with caution!
+
 Stacking middleware
 -------------------
 

--- a/streaq/__init__.py
+++ b/streaq/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-VERSION = "6.3.3"
+VERSION = "6.3.4"
 __version__ = VERSION
 
 logger = logging.getLogger(__name__)

--- a/streaq/worker.py
+++ b/streaq/worker.py
@@ -7,17 +7,13 @@ import warnings
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
+from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone, tzinfo
+from functools import wraps
 from hashlib import sha256
-from inspect import iscoroutinefunction
+from inspect import iscoroutinefunction, signature
 from textwrap import shorten
-from typing import (
-    Any,
-    Generic,
-    Literal,
-    cast,
-    overload,
-)
+from typing import Any, Generic, Literal, cast, overload
 from uuid import UUID, uuid4
 
 from anyio import (
@@ -87,6 +83,7 @@ from streaq.types import (
     Middleware,
     P,
     R,
+    ReturnCoroutine,
     StreamMessage,
     Streaq,
     StreaqCancelled,
@@ -94,6 +91,7 @@ from streaq.types import (
     StreaqRetry,
     SyncCron,
     SyncTask,
+    TaskContext,
     TaskDecorator,
     _TaskDepends,  # pyright: ignore[reportPrivateUsage]
     _WorkerDepends,  # pyright: ignore[reportPrivateUsage]
@@ -206,6 +204,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         "_redis",
         "_running_tasks",
         "_sentinel",
+        "_task_context",
     )
 
     def __init__(
@@ -316,6 +315,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         self._running_tasks: dict[str, set[str]] = defaultdict(set)
         self._limiter = CapacityLimiter(self.sync_concurrency)
         self._initialized = False
+        self._task_context: ContextVar[TaskContext] = ContextVar("_task_context")
         # precalculate Redis prefixes
         self.prefix = REDIS_PREFIX + self.queue_name
         self.cron_data_key = self.prefix + REDIS_CRON + "data:"
@@ -554,12 +554,33 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
             return wrapped(fn)
         return wrapped
 
-    def middleware(self, fn: Middleware) -> Middleware:
+    def middleware(self, original_middleware: Middleware) -> Middleware:
         """
         Registers the given middleware with the worker.
         """
-        self.middlewares.append(fn)
-        return fn
+
+        @wraps(original_middleware)
+        def modified_middleware(fn: ReturnCoroutine) -> ReturnCoroutine:
+            original_handler = original_middleware(fn)
+            depends = {
+                k: type(v.default)
+                for k, v in signature(original_handler).parameters.items()
+                if isinstance(v.default, (_TaskDepends, _WorkerDepends))
+            }
+
+            @wraps(original_handler)
+            async def modified_handler(*args: Any, **kwargs: Any) -> Any:
+                for k, v in depends.items():
+                    if v is _TaskDepends:
+                        kwargs.setdefault(k, self._task_context.get())
+                    else:
+                        kwargs.setdefault(k, self._context)
+                return await original_handler(*args, **kwargs)
+
+            return modified_handler
+
+        self.middlewares.append(modified_middleware)
+        return modified_middleware
 
     def run_sync(self) -> None:
         """
@@ -1071,25 +1092,28 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                     ttl=task.ttl,
                 )
 
+        task_context = task.build_context(task_id, task_try)
         args = data["a"] if not after else self.deserialize(await previous)  # type: ignore
         kwargs = data["k"]
-        for k, v in task.depends.items():
-            if v is _WorkerDepends:
-                kwargs.setdefault(k, self._context)
-            elif v is _TaskDepends:
-                kwargs.setdefault(k, task.build_context(task_id, task_try))
         start_time = now_ms()
         success = True
         schedule = None
         done = True
 
-        async def _fn(*args: Any, **kwargs: Any) -> Any:
+        async def fn(*args: Any, **kwargs: Any) -> Any:
+            # inject dependencies
+            for k, v in task.depends.items():
+                if v is _WorkerDepends:
+                    kwargs.setdefault(k, self._context)
+                elif v is _TaskDepends:
+                    kwargs.setdefault(k, task_context)
+            # run underlying task function
             if iscoroutinefunction(task.fn):
                 return await task.fn(*args, **kwargs)
             return await asyncify(task.fn, self._limiter)(*args, **kwargs)
 
         # apply middlewares in reverse order
-        wrapped = _fn
+        wrapped = fn
         for middleware in reversed(self.middlewares):
             wrapped = middleware(wrapped)
         result: Any = None
@@ -1097,6 +1121,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
         original_deadline = scope.deadline
         self._cancel_scopes[task_id] = scope
         self._running_tasks[msg.priority].add(msg.message_id)
+        token = self._task_context.set(task_context)
         if not task.silent:
             logger.info(f"task {task.fn_name} □ {task_id} → worker {self.id}")
         try:
@@ -1153,6 +1178,7 @@ class Worker(AsyncContextManagerMixin, Generic[C]):
                     success, done = False, False
         finally:
             self._cancel_scopes.pop(task_id, None)
+            self._task_context.reset(token)
             try:
                 self._running_tasks[msg.priority].remove(msg.message_id)
             except KeyError:  # pragma: no cover

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -14,6 +15,7 @@ from streaq.types import (
     StreaqRetry,
     TaskContext,
     TaskDepends,
+    WorkerDepends,
 )
 from streaq.utils import gather
 from streaq.worker import Worker
@@ -465,6 +467,76 @@ async def test_middleware(worker: Worker):
         res = await task.result(3)
         assert res.success
         assert res.result == 4
+
+
+async def test_middleware_with_dependencies(redis_url: str):
+
+    @asynccontextmanager
+    async def lifespan():
+        yield 1
+
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex, lifespan=lifespan)
+
+    @worker.task
+    async def foobar() -> int:
+        return 2
+
+    @worker.middleware
+    def retry(task: ReturnCoroutine) -> ReturnCoroutine:
+        async def wrapper(
+            *args,
+            ctx: TaskContext = TaskDepends(),
+            worker_context: int = WorkerDepends(),
+            **kwargs,
+        ) -> Any:
+            res: int = await task(*args, **kwargs)
+            if worker_context + ctx.tries <= res:
+                raise StreaqRetry("Not enough!")
+            return res
+
+        return wrapper
+
+    async with run_worker(worker):
+        task = await foobar.enqueue()
+        res = await task.result(3)
+        assert res.success
+        assert res.result == 2
+
+
+async def test_middleware_duplicate_param_names(redis_url: str):
+
+    @asynccontextmanager
+    async def lifespan():
+        yield 1
+
+    worker = Worker(redis_url=redis_url, queue_name=uuid4().hex, lifespan=lifespan)
+
+    @worker.task
+    async def incr(val: int, ctx: int = WorkerDepends()) -> int:
+        assert ctx == 1
+        return val + ctx
+
+    @worker.middleware
+    def first(task: ReturnCoroutine) -> ReturnCoroutine:
+        async def wrapper(*args, ctx: TaskContext = TaskDepends(), **kwargs) -> Any:
+            assert isinstance(ctx, TaskContext)
+            return await task(*args, **kwargs)
+
+        return wrapper
+
+    @worker.middleware
+    def second(task: ReturnCoroutine) -> ReturnCoroutine:
+        async def wrapper(*args, ctx: int = WorkerDepends(), **kwargs) -> Any:
+            assert ctx == 1
+            return await task(*args, **kwargs)
+
+        return wrapper
+
+    async with run_worker(worker):
+        task = await incr.enqueue(1)
+        res = await task.result(3)
+        assert res.success
+        assert res.result == 2
 
 
 async def test_task_pipeline(worker: Worker):


### PR DESCRIPTION
## Description
Changes to the dependency injection system in v6.3.2 unintentionally resulted in losing the ability to use DI in middlewares. This adds the functionality back by adding a context var for task context, but without changing the improvements in v6.3.2.

## Related issue(s)
See #154

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`)
- [x] New tests added (if applicable)
- [x] Docs updated (if applicable)
